### PR TITLE
Expose `hash` as an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function Form(options) {
   self.maxFieldsSize = options.maxFieldsSize || 2 * 1024 * 1024;
   self.uploadDir = options.uploadDir || os.tmpDir();
   self.encoding = options.encoding || 'utf8';
-  self.hash = false;
+  self.hash = options.hash || false;
 
   self.bytesReceived = 0;
   self.bytesExpected = null;


### PR DESCRIPTION
Currently, you need to set the `hash` property after a form object has been created. It looks like this is a convention carried over from formidable. This makes it impossible to calculate a hash when using connect-multiparty.

This adds the ability to set it as an option that's passed to the constructor, rather than having to set the property after instantiation. Also, this makes it follow the same convention as the other configurations (maxFields, encoding, etc).

Thanks!
