### PR TITLE
Throwing the aborted exception seems to be unnecessary. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ Form.prototype.parse = function(req, cb) {
   });
   req.on('aborted', function() {
     self.emit('aborted');
-    error(self, new Error("Request aborted"));
+    //error(self, new Error("Request aborted"));
   });
 
   self.bytesExpected = getBytesExpected(req.headers);


### PR DESCRIPTION
Throwing the aborted exception seems to be unnecessary
In addition to that it's difficult to catch it in a real application.

If the client aborts the connection I'm receiving many exceptions like this:
Unhandled exception AssertionError: Error: Request aborted
    at IncomingMessage.<anonymous> (node_modules/multiparty/index.js:93:17)
    at IncomingMessage.EventEmitter.emit (events.js:92:17)
    at abortIncoming (http.js:1881:11)
    at Socket.socket.onend (http.js:1973:7)
    at Socket.g (events.js:175:14)
    at Socket.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:910:16
    at process._tickCallback (node.js:415:13) 
 stack: AssertionError: Error: Request aborted
