### PR TITLE
Support utf-8 filename in Content-Disposition

### DIFF
--- a/index.js
+++ b/index.js
@@ -599,8 +599,16 @@ function uploadPath(baseDir, filename) {
 }
 
 function parseFilename(headerValue) {
-  var m = headerValue.match(/\bfilename="(.*?)"($|; )/i) || headerValue.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/i);
-  if (!m) return;
+  var m = headerValue.match(/\bfilename="(.*?)"($|; )/i);
+  if (!m) {
+    m = headerValue.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/i);
+    if (m) {
+      m[1] = decodeURI(m[1]);
+    }
+    else {
+      return;
+    }
+  }
 
   var filename = m[1].substr(m[1].lastIndexOf('\\') + 1);
   filename = filename.replace(/%22/g, '"');

--- a/test/standalone/test-issue-32.js
+++ b/test/standalone/test-issue-32.js
@@ -1,0 +1,36 @@
+var assert = require('assert');
+var http = require('http');
+var net = require('net');
+var multiparty = require('../../');
+
+var client;
+var server = http.createServer(function(req, res) {
+  var form = new multiparty.Form();
+
+  form.parse(req, function(err, fields, files) {
+    if (err) {
+      console.error(err.stack);
+      return;
+    }
+    assert.strictEqual(files.image[0].originalFilename, "测试文档")
+    res.end();
+    client.end();
+    server.close();
+  });
+});
+server.listen(function() {
+  client = net.connect(server.address().port);
+
+  client.write(
+    "POST /upload HTTP/1.1\r\n" +
+    "Accept: */*\r\n" +
+    "Content-Type: multipart/form-data; boundary=\"893e5556-f402-4fec-8180-c59333354c6f\"\r\n" +
+    "Content-Length: 187\r\n" +
+    "\r\n" +
+    "--893e5556-f402-4fec-8180-c59333354c6f\r\n" +
+    "Content-Disposition: form-data; name=\"image\"; filename*=utf-8''%E6%B5%8B%E8%AF%95%E6%96%87%E6%A1%A3\r\n" +
+    "\r\n" +
+    "\r\n" +
+    "--893e5556-f402-4fec-8180-c59333354c6f--\r\n"
+  );
+});


### PR DESCRIPTION
`SuperAgent` doesn't generate utf-8 filename in `Content-Disposition` (did I miss something?)
So there's no new test for this fix :(
