### PR TITLE
Add test directory to npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 test/ 
+examples/


### PR DESCRIPTION
The test directory consumes 3.5MB. While that in itself is not very much, many modules depend on node-multiparty. More notably connect, which in turn has over 700 dependents. All in all, it results in a lot of bandwidth and storage consumption which I think is unnecessary.

If people want to run tests code, they can clone the repo. There's no need for it to be published in npm, I think.
