### PR TITLE
Add option for max files size for autoFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Creates a new form. Options:
  * `maxFields` - Limits the number of fields that will be parsed before
    emitting an `error` event. A file counts as a field in this case.
    Defaults to 1000.
+ * `maxFilesSize` - Only relevant when `autoFiles` is `true`.  Limits the
+   total bytes accepted for all files combined. If this value is exceeded,
+   an `error` event is emitted. The default is `Infinity`.
  * `autoFields` - Enables `field` events. This is automatically set to `true`
    if you add a `field` listener.
  * `autoFiles` - Enables `file` events. This is automatically set to `true`
@@ -158,6 +161,8 @@ event is emitted. This is typically when you would send your response.
 **By default multiparty will not touch your hard drive.** But if you add this
 listener, multiparty automatically sets `form.autoFiles` to `true` and will
 stream uploads to disk for you. 
+
+**The max bytes accepted per request can be specified with `maxFilesSize`.**
 
  * `name` - the field name for this file
  * `file` - an object with these properties:

--- a/test/standalone/test-max-files-size.js
+++ b/test/standalone/test-max-files-size.js
@@ -1,0 +1,44 @@
+var http = require('http')
+  , multiparty = require('../../')
+  , assert = require('assert')
+  , superagent = require('superagent')
+  , path = require('path')
+  , fs = require('fs')
+
+var server = http.createServer(function(req, res) {
+  assert.strictEqual(req.url, '/upload');
+  assert.strictEqual(req.method, 'POST');
+
+  var form = new multiparty.Form({autoFiles:true,maxFilesSize:800*1024});
+
+  var first = true;
+  form.on('error', function (err) {
+    assert.ok(first);
+    first = false;
+    assert.ok(/maxFilesSize/.test(err.message));
+    server.close();
+  });
+
+  var fileCount = 0;
+  form.on('file', function(name, file) {
+    fileCount += 1;
+    fs.unlink(file.path, function() {});
+  });
+
+  form.parse(req, function(err, fields, files) {
+    assert.ok(fileCount <= 1);
+    res.end();
+  });
+});
+server.listen(function() {
+  var url = 'http://localhost:' + server.address().port + '/upload';
+  var req = superagent.post(url);
+  req.attach('file0', fixture('pf1y5.png'), 'SOG1.JPG');
+  req.attach('file1', fixture('pf1y5.png'), 'SOG2.JPG');
+  req.on('error', function(){});
+  req.end();
+});
+
+function fixture(name) {
+  return path.join(__dirname, '..', 'fixture', 'file', name)
+}


### PR DESCRIPTION
This is my attempt to add the ability to specify a maximum size when using the `autoFiles` option. This works like the `maxFieldsSize` option in that the `maxFilesSize` option counts the combined bytes of all the files.

Note that the file cleanup was moved to a `destroyFile` function, which will correctly remove the file if the `fd` has not closed by that time and keeps it from `ENOENT` errors when the `fd` had never opened before the `destroy` call.

closes #26
