### PR TITLE
Fix maxFilesSize from overcalculating total files size

### DIFF
--- a/index.js
+++ b/index.js
@@ -532,6 +532,7 @@ function handleFile(self, fileStream) {
   }
   counter.on('progress', function() {
     var deltaBytes = counter.bytes - seenBytes;
+    seenBytes += deltaBytes;
     self.totalFileSize += deltaBytes;
     if (self.totalFileSize > self.maxFilesSize) {
       if (hashWorkaroundStream) fileStream.unpipe(hashWorkaroundStream);

--- a/test/standalone/test-max-files-size-exact.js
+++ b/test/standalone/test-max-files-size-exact.js
@@ -1,0 +1,37 @@
+var http = require('http')
+  , multiparty = require('../../')
+  , assert = require('assert')
+  , superagent = require('superagent')
+  , path = require('path')
+  , fs = require('fs')
+
+var server = http.createServer(function(req, res) {
+  assert.strictEqual(req.url, '/upload');
+  assert.strictEqual(req.method, 'POST');
+
+  var form = new multiparty.Form({autoFiles:true,maxFilesSize:768323}); // exact size of pf1y5.png
+
+  var fileCount = 0;
+  form.on('file', function(name, file) {
+    fileCount += 1;
+    fs.unlink(file.path, function() {});
+  });
+
+  form.parse(req, function(err, fields, files) {
+    assert.ifError(err);
+    assert.ok(fileCount === 1);
+    res.end();
+    server.close();
+  });
+});
+server.listen(function() {
+  var url = 'http://localhost:' + server.address().port + '/upload';
+  var req = superagent.post(url);
+  req.attach('file0', fixture('pf1y5.png'), 'SOG1.JPG');
+  req.on('error', function(){});
+  req.end();
+});
+
+function fixture(name) {
+  return path.join(__dirname, '..', 'fixture', 'file', name)
+}


### PR DESCRIPTION
This fixes a bug where the total files size seen was over calculated, so the request would be rejected before actually reaching the limit.

Fixes #47
