### PR TITLE
Improve parsing boundary attribute from Content-Type

### DIFF
--- a/test/fixture/http/content-type/charset-last.http
+++ b/test/fixture/http/content-type/charset-last.http
@@ -1,0 +1,13 @@
+POST /upload HTTP/1.1
+Host: localhost:8080
+Content-Type: multipart/form-data; boundary=----TLV0SrKD4z1TRxRhAPUvZ; charset=utf-8
+Content-Length: 221
+
+------TLV0SrKD4z1TRxRhAPUvZ
+Content-Disposition: form-data; name="file"; filename="plain.txt"
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+I am a plain text file
+
+------TLV0SrKD4z1TRxRhAPUvZ--

--- a/test/fixture/http/content-type/charset.http
+++ b/test/fixture/http/content-type/charset.http
@@ -1,0 +1,13 @@
+POST /upload HTTP/1.1
+Host: localhost:8080
+Content-Type: multipart/form-data; charset=utf-8; boundary=----TLV0SrKD4z1TRxRhAPUvZ
+Content-Length: 221
+
+------TLV0SrKD4z1TRxRhAPUvZ
+Content-Disposition: form-data; name="file"; filename="plain.txt"
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+I am a plain text file
+
+------TLV0SrKD4z1TRxRhAPUvZ--

--- a/test/fixture/http/content-type/custom.http
+++ b/test/fixture/http/content-type/custom.http
@@ -1,0 +1,13 @@
+POST /upload HTTP/1.1
+Host: localhost:8080
+Content-Type: multipart/form-data; custom=stuff; boundary=----TLV0SrKD4z1TRxRhAPUvZ
+Content-Length: 221
+
+------TLV0SrKD4z1TRxRhAPUvZ
+Content-Disposition: form-data; name="file"; filename="plain.txt"
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+I am a plain text file
+
+------TLV0SrKD4z1TRxRhAPUvZ--

--- a/test/fixture/js/content-type.js
+++ b/test/fixture/js/content-type.js
@@ -1,0 +1,32 @@
+module.exports['charset.http'] = [
+  {
+    type: 'file',
+    name: 'file',
+    filename: 'plain.txt',
+    fixture: 'plain.txt',
+    sha1: 'b31d07bac24ac32734de88b3687dddb10e976872',
+    size: 23,
+  }
+];
+
+module.exports['charset-last.http'] = [
+  {
+    type: 'file',
+    name: 'file',
+    filename: 'plain.txt',
+    fixture: 'plain.txt',
+    sha1: 'b31d07bac24ac32734de88b3687dddb10e976872',
+    size: 23,
+  }
+];
+
+module.exports['custom.http'] = [
+  {
+    type: 'file',
+    name: 'file',
+    filename: 'plain.txt',
+    fixture: 'plain.txt',
+    sha1: 'b31d07bac24ac32734de88b3687dddb10e976872',
+    size: 23,
+  }
+];


### PR DESCRIPTION
This changes the regular expression to parse the Content-Type to generically look at the attributes, such that unknown ones are just ignored. This causes the charset attribute to just be ignored.

Fixes #29
