### PR TITLE
Keep part.byteCount undefined in chunked encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -452,10 +452,10 @@ Form.prototype.onParseHeadersEnd = function(offset) {
   self.destStream.filename = self.partFilename;
   self.destStream.byteOffset = self.bytesReceived + offset;
   var partContentLength = self.destStream.headers['content-length'];
-  self.destStream.byteCount = partContentLength ?
-    parseInt(partContentLength, 10) :
-    (self.bytesExpected - self.destStream.byteOffset -
-     self.boundary.length - LAST_BOUNDARY_SUFFIX_LEN);
+  self.destStream.byteCount = partContentLength ? parseInt(partContentLength, 10) :
+    self.bytesExpected ? (self.bytesExpected - self.destStream.byteOffset -
+      self.boundary.length - LAST_BOUNDARY_SUFFIX_LEN) :
+    undefined;
 
   self.emit('part', self.destStream);
   if (self.destStream.filename == null && self.autoFields) {

--- a/test/standalone/test-chunked.js
+++ b/test/standalone/test-chunked.js
@@ -1,0 +1,42 @@
+var multiparty = require('../../')
+  , assert = require('assert')
+  , http = require('http')
+  , net = require('net');
+
+var server = http.createServer(function(req, resp) {
+  var form = new multiparty.Form();
+
+  var partCount = 0;
+  form.on('part', function(part) {
+    partCount++;
+    assert.strictEqual(typeof part.byteCount, 'undefined');
+  });
+  form.on('close', function() {
+    assert.strictEqual(partCount, 1);
+    resp.end();
+  });
+
+  form.parse(req);
+});
+server.listen(function() {
+  var socket = net.connect(server.address().port, 'localhost', function () {
+    socket.write('POST / HTTP/1.1\r\n');
+    socket.write('Host: localhost\r\n');
+    socket.write('Connection: close\r\n');
+    socket.write('Content-Type: multipart/form-data; boundary=foo\r\n');
+    socket.write('Transfer-Encoding: chunked\r\n');
+    socket.write('\r\n');
+    socket.write('7\r\n');
+    socket.write('--foo\r\n\r\n');
+    socket.write('56\r\n');
+    socket.write('Content-Disposition: form-data; name="file"; filename="plain.txt"\r\n\r\n');
+    socket.write('12\r\n');
+    socket.write('\r\nsome text here\r\n\r\n');
+    socket.write('9\r\n');
+    socket.write('--foo--\r\n\r\n');
+    socket.end('0\r\n');
+    socket.on('close', function () {
+      server.close();
+    });
+  });
+});


### PR DESCRIPTION
This sets `part.byteCount` to `undefiend` instead of a negative number when there is not `Content-Length` available, which would be when the `Transfer-Encoding` is chunked and the part does not have a `Content-Length` header. Prior to this, `part.byteCount` would be a negative number, which was useless.

Fixes #55
