### PR TITLE
remove stream object from emitted file parts

### DIFF
--- a/index.js
+++ b/index.js
@@ -613,6 +613,7 @@ function handleFile(self, fileStream) {
   file.ws.on('close', function() {
     if (hash) file.hash = hash.digest('hex');
     file.size = counter.bytes;
+    delete file.ws; // stream is no more of any use in emitted file
     self.emit('file', fileStream.name, file);
     endFlush(self);
   });


### PR DESCRIPTION
Hello,

I have encountered a stack overflow exception with the last connect-multiparty module version when using domains. The root cause is a clone function in the qs library used by connect-multiparty trying to clone the ws (WriteStream) object referenced by the file object emitted by node-multiparty.

Once the file stream has been closed, I think it is not needed anymore and we can safely delete it from the emitted file and avoid unhappy interactions. What do you think of it ?

Regards
