### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ form.on('part', function(part) {
   if (part.filename) {
     // filename is defined when this is a file
     count++;
-    console.log('got file named ' + part.name);
+    console.log('got file named ' + part.filename);
     // ignore file's content here
     part.resume();
   }


### PR DESCRIPTION
`file.name` refers to the field name, while the filename is what the comment suggests should be logged.
