### PR TITLE
Uninitialized variable error

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,11 @@ function Form(options) {
   self.totalFileSize = 0;
   self.flushing = 0;
 
+
+  self.headerFieldMark = 0;
+  self.headerValueMark = 0;
+  self.partDataMark = 0;
+
   self.backpressure = false;
   self.writeCbs = [];
 

--- a/index.js
+++ b/index.js
@@ -74,10 +74,9 @@ function Form(options) {
   self.totalFileSize = 0;
   self.flushing = 0;
 
-
-  self.headerFieldMark = 0;
-  self.headerValueMark = 0;
-  self.partDataMark = 0;
+  self.headerFieldMark = null;
+  self.headerValueMark = null;
+  self.partDataMark = null;
 
   self.backpressure = false;
   self.writeCbs = [];


### PR DESCRIPTION
when package is to small， in first _write call， Uninitialized variable causes the entire state machine exception
headerFieldMark、headerValueMark、partDataMark