### PR TITLE
Fix use of RegExp dot to match all chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ var Z = 122;
 
 var CONTENT_TYPE_RE = /^multipart\/(?:form-data|related)(?:;|$)/i;
 var CONTENT_TYPE_PARAM_RE = /;\s*([^=]+)=(?:"([^"]+)"|([^;]+))/gi;
-var FILE_EXT_RE = /(\.[_\-a-zA-Z0-9]{0,16}).*/;
+var FILE_EXT_RE = /(\.[_\-a-zA-Z0-9]{0,16})[\S\s]*/;
 var LAST_BOUNDARY_SUFFIX_LEN = 4; // --\r\n
 
 // replace base64 characters with safe-for-filename characters


### PR DESCRIPTION
`/./` is equivalent to `/[^\n\r\u2028\u2029]/` which was probably not intended here.