### PR TITLE
Add sanitization to parseFilename function

### DIFF
--- a/index.js
+++ b/index.js
@@ -769,6 +769,7 @@ function uploadPath(baseDir, filename) {
 }
 
 function parseFilename(headerValue) {
+  headerValue = headerValue.replace(/[^\x00-\x7F]/g,'').
   var m = headerValue.match(/\bfilename="(.*?)"($|; )/i);
   if (!m) {
     m = headerValue.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/i);

--- a/index.js
+++ b/index.js
@@ -769,9 +769,9 @@ function uploadPath(baseDir, filename) {
 }
 
 function parseFilename(headerValue) {
-  var m = headerValue.match(/\bfilename="(.*?)"($|; )/isu);
+  var m = headerValue.match(/\bfilename="(.*?)"($|; )/is);
   if (!m) {
-    m = headerValue.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/isu);
+    m = headerValue.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/is);
     if (m) {
       m[1] = decodeURI(m[1]);
     }

--- a/index.js
+++ b/index.js
@@ -769,7 +769,7 @@ function uploadPath(baseDir, filename) {
 }
 
 function parseFilename(headerValue) {
-  headerValue = headerValue.replace(/[^\x00-\x7F]/g,'').
+  headerValue = headerValue.replace(/[^\x00-\x7F]/g,'');
   var m = headerValue.match(/\bfilename="(.*?)"($|; )/i);
   if (!m) {
     m = headerValue.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/i);

--- a/index.js
+++ b/index.js
@@ -769,10 +769,9 @@ function uploadPath(baseDir, filename) {
 }
 
 function parseFilename(headerValue) {
-  var hv = headerValue.replace(/[^\x00-\x7F]/g,'');
-  var m = hv.match(/\bfilename="(.*?)"($|; )/i);
+  var m = headerValue.match(/\bfilename="(.*?)"($|; )/isu);
   if (!m) {
-    m = hv.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/i);
+    m = headerValue.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/isu);
     if (m) {
       m[1] = decodeURI(m[1]);
     }

--- a/index.js
+++ b/index.js
@@ -769,10 +769,10 @@ function uploadPath(baseDir, filename) {
 }
 
 function parseFilename(headerValue) {
-  headerValue = headerValue.replace(/[^\x00-\x7F]/g,'');
-  var m = headerValue.match(/\bfilename="(.*?)"($|; )/i);
+  var hv = headerValue.replace(/[^\x00-\x7F]/g,'');
+  var m = hv.match(/\bfilename="(.*?)"($|; )/i);
   if (!m) {
-    m = headerValue.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/i);
+    m = hv.match(/\bfilename\*=utf-8\'\'(.*?)($|; )/i);
     if (m) {
       m[1] = decodeURI(m[1]);
     }


### PR DESCRIPTION
When a form is sent with a file whose name contains special characters, this name is not encoded, the match function is not able to resolve the header value and returns null, causing the file not to be interpreted correctly. By removing the special characters (sanitize the value) the function continues to work correctly.