### PR TITLE
onReqAborted should only throw an error if close event has not been fired

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Fix empty files on Node.js 14.x
+  * Fix form emitting aborted error after close
   * Replace `fd-slicer` module with internal transform stream
   * deps: http-errors@~1.8.0
     - Fix error creating objects in some environments

--- a/index.js
+++ b/index.js
@@ -91,6 +91,8 @@ Form.prototype.parse = function(req, cb) {
   var self = this;
   var waitend = true;
 
+  self.on('close', onClosed)
+
   if (cb) {
     // if the user supplies a callback, this implies autoFields and autoFiles
     self.autoFields = true;
@@ -182,6 +184,10 @@ Form.prototype.parse = function(req, cb) {
 
   setUpParser(self, boundary);
   req.pipe(self);
+
+  function onClosed () {
+    req.removeListener('aborted', onReqAborted)
+  }
 
   function onReqAborted() {
     waitend = false;


### PR DESCRIPTION
This PR attempts to fix the bug described in this issue https://github.com/pillarjs/multiparty/issues/138