### PR TITLE
test fixtureServer: insecureHTTPParser to allow LF

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1435,7 +1435,7 @@ describe('multiparty', function () {
   })
 
   describe('fixture tests', function () {
-    var fixtureServer = http.createServer()
+    var fixtureServer = http.createServer({ insecureHTTPParser: true })
     var fixtureTests = requireAll(path.join(FIXTURE_PATH, 'js'))
 
     before(function (done) {


### PR DESCRIPTION
Otherwise it fails with node 18, which strictly expects CRLF for lines breaks in HTTP headers.